### PR TITLE
Render source handles on click

### DIFF
--- a/client/src/canvas/custom_node.js
+++ b/client/src/canvas/custom_node.js
@@ -11,9 +11,10 @@ const targetHandleStyle = {
   borderRadius: 5,
   background: "transparent",
   border: "transparent",
-  zIndex: 999,
+  zIndex: -1,
   width: "inherit",
   height: "inherit",
+  top: "0px",
 };
 
 const sourceHandleStyle = {
@@ -112,39 +113,51 @@ const CustomNodeComponent = (props) => {
           "z-index": `${props.data.floatTargetHandle ? 9999 : -1}`,
         }}
       />
-      {/* Only render handles when node is selected */}
-      {true && (
-        <>
-          <Handle
-            className="handle source"
-            id={`top-handle-${props.id}`}
-            type="source"
-            position="top"
-            style={{ ...sourceHandleStyle, top: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`bottom-handle-${props.id}`}
-            type="source"
-            position="bottom"
-            style={{ ...sourceHandleStyle, bottom: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`left-handle-${props.id}`}
-            type="source"
-            position="left"
-            style={{ ...sourceHandleStyle, left: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`right-handle-${props.id}`}
-            type="source"
-            position="right"
-            style={{ ...sourceHandleStyle, right: "-20px" }}
-          />
-        </>
-      )}
+      {/* Only display handles when node is selected */}
+      <Handle
+        className="handle source"
+        id={`top-handle-${props.id}`}
+        type="source"
+        position="top"
+        style={{ 
+          ...sourceHandleStyle, 
+          top: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`bottom-handle-${props.id}`}
+        type="source"
+        position="bottom"
+        style={{ 
+          ...sourceHandleStyle, 
+          bottom: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`left-handle-${props.id}`}
+        type="source"
+        position="left"
+        style={{ 
+          ...sourceHandleStyle, 
+          left: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`right-handle-${props.id}`}
+        type="source"
+        position="right"
+        style={{ 
+          ...sourceHandleStyle, 
+          right: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
     </Resizable>
   );
 };
@@ -222,40 +235,51 @@ const WrapperNodeComponent = (props) => {
           "z-index": `${props.data.floatTargetHandle ? 9999 : -1}`,
         }}
       />
-
-      {/* Only render handles when node is selected */}
-      {true && (
-        <>
-          <Handle
-            className="handle source"
-            id={`top-handle-${props.id}`}
-            type="source"
-            position="top"
-            style={{ ...sourceHandleStyle, top: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`bottom-handle-${props.id}`}
-            type="source"
-            position="bottom"
-            style={{ ...sourceHandleStyle, bottom: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`left-handle-${props.id}`}
-            type="source"
-            position="left"
-            style={{ ...sourceHandleStyle, left: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`right-handle-${props.id}`}
-            type="source"
-            position="right"
-            style={{ ...sourceHandleStyle, right: "-20px" }}
-          />
-        </>
-      )}
+      {/* Only display handles when node is selected */}
+      <Handle
+        className="handle source"
+        id={`top-handle-${props.id}`}
+        type="source"
+        position="top"
+        style={{ 
+          ...sourceHandleStyle, 
+          top: "-20px", 
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`bottom-handle-${props.id}`}
+        type="source"
+        position="bottom"
+        style={{ 
+          ...sourceHandleStyle, 
+          bottom: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`left-handle-${props.id}`}
+        type="source"
+        position="left"
+        style={{ 
+          ...sourceHandleStyle, 
+          left: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`right-handle-${props.id}`}
+        type="source"
+        position="right"
+        style={{ 
+          ...sourceHandleStyle, 
+          right: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
     </Resizable>
   );
 };
@@ -333,40 +357,50 @@ const FolderNodeComponent = (props) => {
           "z-index": `${props.data.floatTargetHandle ? 9999 : -1}`,
         }}
       />
-
-      {/* Only render handles when node is selected */}
-      {true && (
-        <>
-          <Handle
-            className="handle source"
-            id={`top-handle-${props.id}`}
-            type="source"
-            position="top"
-            style={{ ...sourceHandleStyle, top: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`bottom-handle-${props.id}`}
-            type="source"
-            position="bottom"
-            style={{ ...sourceHandleStyle, bottom: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`left-handle-${props.id}`}
-            type="source"
-            position="left"
-            style={{ ...sourceHandleStyle, left: "-20px" }}
-          />
-          <Handle
-            className="handle source"
-            id={`right-handle-${props.id}`}
-            type="source"
-            position="right"
-            style={{ ...sourceHandleStyle, right: "-20px" }}
-          />
-        </>
-      )}
+      <Handle
+        className="handle source"
+        id={`top-handle-${props.id}`}
+        type="source"
+        position="top"
+        style={{ 
+          ...sourceHandleStyle, 
+          top: "-20px", 
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`bottom-handle-${props.id}`}
+        type="source"
+        position="bottom"
+        style={{ 
+          ...sourceHandleStyle, 
+          bottom: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`left-handle-${props.id}`}
+        type="source"
+        position="left"
+        style={{ 
+          ...sourceHandleStyle, 
+          left: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
+      <Handle
+        className="handle source"
+        id={`right-handle-${props.id}`}
+        type="source"
+        position="right"
+        style={{ 
+          ...sourceHandleStyle, 
+          right: "-20px",
+          display: `${props.selected ? "block" : "none"}`,
+        }}
+      />
     </Resizable>
   );
 };


### PR DESCRIPTION
### Description
Source handles for nodes should only be visible and interactable when a user first clicks/selects a node. This PR should also fix the bug where edges were not being created when a user tries to make a connection between 2 nodes.

### Testing
1. Create a bunch of different nodes (ie. linked file nodes, circle nodes, dashed border nodes, etc). 
2. Source handles should not be visible, unless you click on a particular node. 
3. Try creating edges/ connecting nodes to each other. Edges should be rendered between nodes.

### NOTE TO SELF:
This PR is comparing `render-handles-on-click` to `unlink-files-delete-node`. After approval, I need to rebase `unlink-files-delete-node` to `develop` and then merge code.