### PR TITLE
Pan to node

### DIFF
--- a/client/src/SourceDoc/SourceDocFile.js
+++ b/client/src/SourceDoc/SourceDocFile.js
@@ -55,8 +55,6 @@ function SourceDocFile(props) {
         node.data ? node.data.path === file.path : false
       );
       if (el) {
-        console.log("SourceDoc selectedFile el\n", el);
-        console.log("SourceDoc selectedFile\n", file);
         const x = el.position.x + el.width / 2;
         const y = el.position.y + el.height / 2;
         


### PR DESCRIPTION
Clicking on a file path from the SourceDoc > Repo tab should pan you to the corresponding node on the Canvas. 
(should only work when you click on a file path that has a node already on the canvas. If a node doesn't exist for the file path you clicked on, you shouldn't see anything difference)